### PR TITLE
fix git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "contracts/liquidity_hub/pool-network"]
+	path = contracts/liquidity_hub/pool-network
+	url = git@github.com:White-Whale-Defi-Platform/pool-network.git


### PR DESCRIPTION
`.gitmodules` was removed in a previous commit which means we don't get the contents under `contracts/lquidity_hub/pool-network` when cloning